### PR TITLE
SELC-3127 add backLabel optional prop to NavigationBar

### DIFF
--- a/src/lib/components/BackComponent.tsx
+++ b/src/lib/components/BackComponent.tsx
@@ -3,9 +3,10 @@ import { ButtonNaked } from '@pagopa/mui-italia';
 import { useTranslation } from 'react-i18next';
 type Props = {
   goBack?: () => void;
+  backLabel?: string;
 };
 
-export default function BackComponent({ goBack }: Props) {
+export default function BackComponent({ goBack, backLabel }: Props) {
   const { t } = useTranslation();
   return (
     <ButtonNaked
@@ -16,7 +17,7 @@ export default function BackComponent({ goBack }: Props) {
       sx={{ color: 'primary.main' }}
       weight="default"
     >
-      {t('common.backComponent.label')}
+      {backLabel ? backLabel : t('common.backComponent.label')}
     </ButtonNaked>
   );
 }

--- a/src/lib/components/NavigationBar.tsx
+++ b/src/lib/components/NavigationBar.tsx
@@ -7,6 +7,7 @@ import BackComponent from './BackComponent';
 type Props = {
   paths: Array<NavigationPath>;
   goBack?: () => void;
+  backLabel?: string;
   backLinkTextDecoration?: string;
   backLinkFontWeight?: string;
   backLinkFontSize?: string;
@@ -19,7 +20,7 @@ export type NavigationPath = {
   icon?: SvgIconComponent;
 };
 
-export default function NavigationBar({ paths, goBack, showBackComponent }: Props) {
+export default function NavigationBar({ paths, goBack, showBackComponent, backLabel}: Props) {
   const onExit = useUnloadEventOnExit();
 
   const truncatedText = {
@@ -34,7 +35,7 @@ export default function NavigationBar({ paths, goBack, showBackComponent }: Prop
     <Box display="flex">
       {showBackComponent && (
         <Box mr={2} display="flex" alignItems={'center'}>
-          <BackComponent goBack={goBack} />
+          <BackComponent goBack={goBack} backLabel={backLabel} />
         </Box>
       )}
       <Box display="flex" alignItems={'center'}>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
 Add backLabel optional prop to NavigationBar
#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context
In order to be able to change the label of the back button for SELC.3127 an optional prop was needed for 
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally with the prop and without
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.