### PR TITLE
[SELC-5006] feat: Added no mandatory second button to EndingPage component and custom button stylization + updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,20 @@ Selfcare's ending page
 
 | Prop | Type | Mandatory | Description |
 |------|------|-----------|-------------|
-| icon | React.ReactElement | N | The ending page icon |
-| title | string | Y | The ending page title |
+| minHeight | '52vh' \| '100vh' | N | The minHeight of the component, can be 52vh for the pages and 100vh for the blocking page |
+| icon | React.ReactElement<SvgIconProps> \| FunctionComponent<SVGProps<SVGSVGElement>> \| string | N | The ending page icon |
+| title | React.ReactNode | Y | The ending page title |
 | description | React.ReactNode | Y | The ending page description | 
-| buttonLabel | string | N | The ending page button label if any |
-| onButtonClick | () => void | N | if defined it will show a button that will performe this action on click |
-| variantTitle | (| 'button'| 'caption'| 'h1'| 'h2'| 'h3'| 'h4'| 'h5'| 'h6'| 'inherit'| 'subtitle1'| 'subtitle2'| 'body1'| 'body2'| 'overline'| undefined;) | N | Set the variant of the title |
-| variantDescription | (| 'button'| 'caption'| 'h1'| 'h2'| 'h3'| 'h4'| 'h5'| 'h6'| 'inherit'| 'subtitle1'| 'subtitle2'| 'body1'| 'body2'| 'overline'| undefined;) | N | Set the variant of the description |
+| buttonLabel | React.ReactNode | N | The ending page button label if any |
+| secondButtonLabel | React.ReactNode | N | The ending page second button label if any |
+| onButtonClick | () => void | N | If defined it will show a button that will perform this action on click |
+| variantTitle | 'button' \| 'caption' \| 'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6' \| 'inherit' \| 'subtitle1' \| 'subtitle2' \| 'body1' \| 'body2' \| 'overline' \| undefined | N | Set the variant of the title |
+| variantDescription |  'button' \| 'caption' \| 'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6' \| 'inherit' \| 'subtitle1' \| 'subtitle2' \| 'body1' \| 'body2' \| 'overline' \| undefined | N | Set the variant of the description |
+| variantFirstButton | 'contained' \| 'outlined' \| 'text' | N | Set the variant of the first button |
+| variantSecondButton | 'contained' \| 'outlined' \| 'text' | N | Set the variant of the second button |
+| paragraph | React.ReactNode | N | Set the text of paragraph |
+| isParagraphPresent | boolean | N | Show the paragraph |
+| haveTwoButtons | boolean | N | Show the second button and the "secondButtonLabel" as text of this one |
 
 ## NavigationBar
 Selfcare's navigation bar

--- a/src/lib/components/EndingPage.tsx
+++ b/src/lib/components/EndingPage.tsx
@@ -12,6 +12,8 @@ type Props = {
   description: React.ReactNode;
   /** The ending page button label if any */
   buttonLabel?: React.ReactNode;
+  /** The ending page second button label if any */
+  secondButtonLabel?: React.ReactNode;
   /** if defined it will show a button that will performe this action on click */
   onButtonClick?: () => void;
   /** Set the variant of the title */
@@ -48,8 +50,16 @@ type Props = {
     | 'body2'
     | 'overline'
     | undefined;
+  /** Set the variant of the first button */
+  variantFirstButton?: 'contained' | 'outlined' | 'text';
+  /** Set the variant of the second button */
+  variantSecondButton?: 'contained' | 'outlined' | 'text';
+  /** Set the text of paragraph */
   paragraph?: React.ReactNode;
+  /** Show the paragraph */
   isParagraphPresent?: boolean;
+  /** Show the second button and the "secondButtonLabel" as text of this one */
+  haveTwoButtons?: boolean;
 };
 
 /** Selfcare's Ending Page */
@@ -64,6 +74,10 @@ export default ({
   variantDescription,
   paragraph,
   isParagraphPresent,
+  haveTwoButtons = false,
+  secondButtonLabel,
+  variantFirstButton = 'contained',
+  variantSecondButton = 'contained',
 }: Props) => (
   <Box sx={{ minHeight, position: 'static' }} display="flex" flexGrow={1}>
     <Grid container direction="column" key="0" style={{ textAlign: 'center' }} margin={'auto'}>
@@ -84,10 +98,23 @@ export default ({
       </Grid>
       {onButtonClick && (
         <Grid container item justifyContent="center">
-          <Grid item xs={4}>
-            <Button variant="contained" sx={{ alignSelf: 'center' }} onClick={onButtonClick}>
+          <Grid item xs={haveTwoButtons ? 12 : 4}>
+            <Button
+              variant={variantFirstButton}
+              sx={{ alignSelf: 'center', marginRight: haveTwoButtons ? 3 : 0 }}
+              onClick={onButtonClick}
+            >
               {buttonLabel}
             </Button>
+            {haveTwoButtons && (
+              <Button
+                variant={variantSecondButton}
+                sx={{ alignSelf: 'center' }}
+                onClick={onButtonClick}
+              >
+                {secondButtonLabel}
+              </Button>
+            )}
           </Grid>
         </Grid>
       )}


### PR DESCRIPTION


<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[SELC-5006] feat: Added no mandatory second button to EndingPage component and custom button stylization + updated README

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Added the possibility to have two button instead of the single one and customize them

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5006]: https://pagopa.atlassian.net/browse/SELC-5006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ