### PR TITLE
[SELC-5248] feat: Regexp email allow domains with 6 characters

### DIFF
--- a/src/lib/utils/constants.ts
+++ b/src/lib/utils/constants.ts
@@ -3,7 +3,7 @@ export const LOADING_TASK_RETRIEVE_CACHED_VALUES = 'RETRIEVE_CACHED_VALUES';
 
 export type UserRole = 'ADMIN' | 'LIMITED' | 'ADMIN_EA';
 
-export const emailRegexp = new RegExp('^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,5}$');
+export const emailRegexp = new RegExp('^[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,6}$');
 
 /** The short and long labels used for the roles of selfcare's projects */
 export const roleLabels: {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

[SELC-5248] feat: Regexp email allow domains with 6 characters

#### Motivation and Context

In order to allow the insertion of more than five characters into the email domain

#### How Has This Been Tested?

local enviroment

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-5248]: https://pagopa.atlassian.net/browse/SELC-5248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ