### PR TITLE
[SELC-5578] Feat: Add CustomAlert Component for Reusable Alert Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,3 +435,15 @@ The tool used is [OneTrust](#https://www.onetrust.it/), and in order to be able 
 | Key | Type | Description | DefaultValue |
 |-----|------|-------------|--------------|
 | COOKIE_GROUP_ANALYTICS | string | The cookie group configured for the analytics tool. MixPanel's cookies are configured as default by OneTrust with C0004 group, or as Targeting Cookies | C0004 |
+
+## CustomAlert
+Reusable component to display information messages using MUI's Alert.
+
+| Prop      | Type  | Mandatory | Description |
+|-----------|-------|-----------|-------------|
+| text      | string  | N         | The message text to display in the alert                    |
+| severity  | 'error' \| 'info' \| 'success' \| 'warning'| N  | The severity level of the alert |
+| variant   | 'filled' \| 'outlined' \| 'standard' | N   | The visual style of the alert        |
+| sx        | object | N         | Additional custom styles for the alert                       |
+| ...rest   | any   | N         | Any additional props passed to MUI's Alert component          |
+

--- a/src/AppExample.tsx
+++ b/src/AppExample.tsx
@@ -1,26 +1,27 @@
+import { SupervisedUserCircle } from '@mui/icons-material';
 import { Box, Button, Grid } from '@mui/material';
 import { useState } from 'react';
-import { SupervisedUserCircle } from '@mui/icons-material';
+import AnalyticsExample from './examples/AnalyticsExample';
+import CustomAlertExample from './examples/CustomAlertExample';
 import CustomAvatarExample from './examples/CustomAvatarExample';
 import CustomPaginationExample from './examples/CustomPaginationExample';
 import FilterModalExample from './examples/FilterModalExample';
+import FooterExample from './examples/FooterExample';
+import HeaderExample from './examples/HeaderExample';
 import SessionModalExample from './examples/SessionModalExample';
 import ToastExample from './examples/ToastExample';
+import TranslationTextExample from './examples/TranslationTextExample';
 import UseErrorDispatcherExample from './examples/UseErrorDispatcherExample';
 import UseLoadingExample from './examples/UseLoadingExample';
-import UseUserNotifyExample from './examples/UseUserNotifyExample';
 import UseUnloadEventInterceptorExample from './examples/UseUnloadEventInterceptorExample';
+import UseUserNotifyExample from './examples/UseUserNotifyExample';
 import { NavigationBar, TitleBox } from './lib';
 import ErrorBoundary from './lib/components/ErrorBoundary/ErrorBoundary';
 import LoadingOverlay from './lib/components/Loading/LoadingOverlay';
 import UnloadEventHandler from './lib/components/UnloadEventHandler';
 import UserNotifyHandle from './lib/components/UserNotifyHandle';
-import withLogin from './lib/decorators/withLogin';
-import AnalyticsExample from './examples/AnalyticsExample';
-import TranslationTextExample from './examples/TranslationTextExample';
 import './lib/consentManagementConfigure';
-import FooterExample from './examples/FooterExample';
-import HeaderExample from './examples/HeaderExample';
+import withLogin from './lib/decorators/withLogin';
 import { useUnloadEventOnExit } from './lib/hooks/useUnloadEventInterceptor';
 
 const AppExample = () => {
@@ -110,6 +111,9 @@ const AppExample = () => {
           <Grid item xs={2}>
             <TranslationTextExample />
           </Grid>
+        </Grid>
+        <Grid>
+          <CustomAlertExample />
         </Grid>
         <FooterExample isLoggedIn={isLoggedIn} />
       </Box>

--- a/src/examples/CustomAlertExample.tsx
+++ b/src/examples/CustomAlertExample.tsx
@@ -1,0 +1,5 @@
+import { CustomAlert } from '../lib';
+
+export default () => (
+  <CustomAlert text="Lorem ipsum odor amet, consectetuer adipiscing elit. Efficitur mi massa blandit; suscipit tempus dapibus. In lacinia iaculis pharetra tellus turpis malesuada. Ut imperdiet eleifend accumsan parturient, maximus" />
+);

--- a/src/lib/components/CustomAlert.tsx
+++ b/src/lib/components/CustomAlert.tsx
@@ -1,0 +1,29 @@
+import { Alert } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+type AlertProps = {
+  /** The text to display in the alert */
+  text?: string;
+  /** The severity level of the alert */
+  severity?: 'error' | 'info' | 'success' | 'warning';
+  /** The visual style of the alert */
+  variant?: 'filled' | 'outlined' | 'standard';
+  /** Additional custom styles */
+  sx?: object;
+};
+
+export default function CustomAlert({
+  text,
+  severity = 'info',
+  variant = 'standard',
+  sx,
+  ...rest
+}: AlertProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Alert role="alert" severity={severity} variant={variant} sx={sx} {...rest}>
+      {text || t('common.customAlert.message')}
+    </Alert>
+  );
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,22 +1,22 @@
-export { default as Header } from './components/Header/Header';
-export { default as Footer } from './components/Footer/Footer';
+export { default as BackComponent } from './components/BackComponent';
 export { default as CustomAvatar } from './components/CustomAvatar';
 export { default as CustomPagination } from './components/CustomPagination';
+export { default as EndingPage } from './components/EndingPage';
 export { default as FilterModal } from './components/FilterModal';
+export { default as Footer } from './components/Footer/Footer';
+export { default as Header } from './components/Header/Header';
+export { default as LoadingOverlayComponent } from './components/LoadingOverlayComponent';
+export { default as NavigationBar } from './components/NavigationBar';
 export { default as SessionModal } from './components/SessionModal';
 export { default as TitleBox } from './components/TitleBox';
 export { default as Toast } from './components/Toast';
 export { default as ToastWrapper } from './components/ToastWrapper';
-export { default as EndingPage } from './components/EndingPage';
-export { default as LoadingOverlayComponent } from './components/LoadingOverlayComponent';
-export { default as NavigationBar } from './components/NavigationBar';
-export { default as BackComponent } from './components/BackComponent';
 
 export { default as CheckIllustrationIcon } from './components/icons/CheckIllustrationIcon';
 export { default as ConfirmIcon } from './components/icons/ConfirmIcon';
 export { default as ErrorIcon } from './components/icons/ErrorIcon';
-export { default as FaultIcon } from './components/icons/FaultIcon';
 export { default as ErrorIconExclamation } from './components/icons/ErrorIconExclamation';
+export { default as FaultIcon } from './components/icons/FaultIcon';
 export { default as PagoPaIcon } from './components/icons/PagoPaIcon';
 export { default as PagoPaMiniIcon } from './components/icons/PagoPaMiniIcon';
 
@@ -32,9 +32,7 @@ export { default as useUserNotify } from './hooks/useUserNotify';
 export { default as UnloadEventHandler } from './components/UnloadEventHandler';
 export {
   useUnloadEventInterceptor,
-  useUnloadEventInterceptorAndActivate,
-  useUnloadEventOnExit,
-  useUnloadEventLogout,
+  useUnloadEventInterceptorAndActivate, useUnloadEventLogout, useUnloadEventOnExit
 } from './hooks/useUnloadEventInterceptor';
 
 export { default as withLogin } from './decorators/withLogin';
@@ -43,6 +41,7 @@ export { useLogin } from './hooks/useLogin';
 export { default as withRetrievedValue } from './decorators/withRetrievedValue';
 export { default as useReduxCachedValue } from './hooks/useReduxCachedValue';
 
+export { default as CustomAlert } from './components/CustomAlert';
 export { default as useFakePagination } from './hooks/useFakePagination';
 export { usePermissions } from './hooks/usePermissions';
 

--- a/src/lib/locale/it.ts
+++ b/src/lib/locale/it.ts
@@ -94,5 +94,8 @@ export default {
     backComponent: {
       label: 'Indietro',
     },
+    customAlert: {
+      message: 'Per migliorare la tua esperienza e offrirti una gestione più mirata, vedrai solo le informazioni e i prodotti di cui sei amministratore.'
+    }
   },
 };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Created a new CustomAlert component.
Supports customizable props such as text, severity, variant, sx for styling and ..rest.
<!--- Describe your changes in detail -->

#### Motivation and Context
To show a info banner for the limited visibility of users in dashboard this PR introduces a new CustomAlert component that leverages MUI’s Alert component to provide a reusable and flexible way to display messages with different severities, styles, and customizations. 
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested by creating an example component and runing it locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.