### PR TITLE
[SELC-5369] Feat: Allow type ReactNode to be passed as title and subTitle

### DIFF
--- a/src/lib/components/TitleBox.tsx
+++ b/src/lib/components/TitleBox.tsx
@@ -3,12 +3,13 @@
 import { Typography } from '@mui/material';
 import { Grid } from '@mui/material';
 import { Variant } from '@mui/material/styles/createTypography';
+import { ReactNode } from 'react';
 
 type Props = {
-  /** The title to show */
-  title: string;
-  /** The subtitle to show */
-  subTitle?: string;
+  /** The title to show (can be a string or JSX) */
+  title: ReactNode;
+  /** The subtitle to show (can be a string or JSX) */
+  subTitle?: ReactNode;
   /** The margin top of the title */
   mtTitle?: number;
   /** The margin bottom of the title */


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
changed title param to allow a type ReactNode to be passed as title to the TitleBox component
changed subTitle param to allow a type ReactNode to be passed as title to the TitleBox component
<!--- Describe your changes in detail -->

#### Motivation and Context
Initially, the subTitle prop was typed as string, which restricted it to plain text only. However, you wanted to use the <Trans> component from react-i18next to provide translations with embedded formatting (e.g., bold text for productName using <strong> tags). The <Trans> component returns JSX, not just a string, so subTitle needed to accept JSX elements or components.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested in the appExample by passing a Translation component in place of string as subtitle
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.