### PR TITLE
[SELC-5842] Feat: Add Selc:ListProductUsers to the Actions enum 

### DIFF
--- a/src/lib/utils/constants.ts
+++ b/src/lib/utils/constants.ts
@@ -50,6 +50,7 @@ export const pnpgRoleLabels: {
 export enum Actions {
   ManageProductGroups = 'Selc:ManageProductGroups',
   ManageProductUsers = 'Selc:ManageProductUsers',
+  ListProductUsers = 'Selc:ListProductUsers',
   ViewDelegations = 'Selc:ViewDelegations',
   ViewManagedInstitutions = 'Selc:ViewManagedInstitutions',
   AccessProductBackoffice = 'Selc:AccessProductBackoffice',


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add new action Selc:ListProductUsers to the enum in order to handle when the users section should be visible.
<!--- Describe your changes in detail -->

#### Motivation and Context
To limit the role of the ADMIN_EA a new action was added to handle users section visibility while the old one will be used to handle what can be done inside the users section.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.