### PR TITLE
[SELC-6042] fix: Ensuring detection language and fix unit tests

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from '@mui/material';
 import { theme } from '@pagopa/mui-italia';
 
 jest.mock('../lib/decorators/withLogin');
+jest.mock('i18next-browser-languagedetector');
 
 const renderApp = (
   injectedStore?: ReturnType<typeof createStore>,

--- a/src/lib/components/ErrorBoundary/components/__tests__/BlockingErrorPage.test.tsx
+++ b/src/lib/components/ErrorBoundary/components/__tests__/BlockingErrorPage.test.tsx
@@ -4,6 +4,8 @@ import { buildAssistanceURI } from '../../../../services/assistanceService';
 import './../../../../../examples/locale';
 import BlockingErrorPage from './../BlockingErrorPage';
 
+jest.mock('i18next-browser-languagedetector');
+
 const oldWindowLocation = global.window.location;
 
 const initialLocation = {

--- a/src/lib/components/tests/FilterModal.test.tsx
+++ b/src/lib/components/tests/FilterModal.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import FilterModal, { FilterModalConfig } from '../FilterModal';
 import './../../../examples/locale';
 
+jest.mock('i18next-browser-languagedetector');
+
 const data = [
   { id: '1', label: 'Option 1' },
   { id: '2', label: 'Option 2' },

--- a/src/lib/hooks/__tests__/useErrorDispatcher.test.tsx
+++ b/src/lib/hooks/__tests__/useErrorDispatcher.test.tsx
@@ -9,6 +9,7 @@ import { handleErrors } from '../../services/errorService';
 import './../../../examples/locale';
 
 jest.mock('../../services/errorService');
+jest.mock('i18next-browser-languagedetector');
 
 const renderApp = (content: ReactNode) => {
   const store = createStore();

--- a/src/lib/hooks/__tests__/useUnloadEventInterceptor.test.tsx
+++ b/src/lib/hooks/__tests__/useUnloadEventInterceptor.test.tsx
@@ -12,6 +12,8 @@ import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 import './../../../examples/locale';
 
+jest.mock('i18next-browser-languagedetector');
+
 const oldWindowLocation = global.window.location;
 
 const initialLocation = {

--- a/src/lib/hooks/__tests__/useUserNotify.test.tsx
+++ b/src/lib/hooks/__tests__/useUserNotify.test.tsx
@@ -6,6 +6,8 @@ import useUserNotify from '../useUserNotify';
 import { UserNotify } from '../../model/UserNotify';
 import './../../../examples/locale';
 
+jest.mock('i18next-browser-languagedetector');
+
 const renderApp = (userNotify: UserNotify) => {
   const store = createStore();
   const Child = buildChildComponent(userNotify);

--- a/src/lib/locale/locale-utils.ts
+++ b/src/lib/locale/locale-utils.ts
@@ -20,11 +20,11 @@ export const configureI18n = (
     sl: { translation: { ...sl, ...resources.sl } },
   };
   i18n
-    .use(initReactI18next)
     .use(LanguageDetector)
+    .use(initReactI18next)
     .init({
       resources: completeResources,
-      lng: defaultLanguage,
+      fallbackLng: defaultLanguage,
       interpolation: {
         escapeValue: false,
       },


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
[SELC-6042] fix: Ensuring detection language and fix unit tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Restored fallbackLanguage instead of lang in order to ensure that the client detect correctly the lang from browser

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

[SELC-6042]: https://pagopa.atlassian.net/browse/SELC-6042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ